### PR TITLE
Only clone latest commit of hyprland

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ progress "[3/7] Setting up hyprland source in $HYPRLAND_PATH"
 if [ -d "$HYPRLAND_PATH" ]; then
     git -C "$HYPRLAND_PATH" pull
 else
-    git clone https://github.com/hyprwm/Hyprland.git "$HYPRLAND_PATH" --recursive
+    git clone https://github.com/hyprwm/Hyprland.git "$HYPRLAND_PATH" --recursive --depth 1
 fi
 
 HYPRLAND_COMMIT=""


### PR DESCRIPTION
As of right now, it clones the entire commit history, while only the latest commit is required.