### PR TITLE
Make hyprload "pure" by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,18 +12,19 @@ INSTALL_PATH=${HOME}/.local/share/hyprload/
 COMPILE_FLAGS=-g -fPIC --no-gnu-unique -I "/usr/include/pixman-1" -I "/usr/include/libdrm" -I "${HYPRLAND_HEADERS}" -Iinclude -std=c++23
 LINK_FLAGS=-shared
 
-.PHONY: clean clangd
+.PHONY: install clean clangd
 
 all: check_env $(PLUGIN_NAME).so
 
 install: all
-	mkdir -p $(INSTALL_PATH)plugins/bin
+	@mkdir -p $(INSTALL_PATH)plugins/bin
 	cp $(PLUGIN_NAME).sh "$(INSTALL_PATH)$(PLUGIN_NAME).sh"
 	@if [ -f "$(INSTALL_PATH)$(PLUGIN_NAME).so" ]; then\
 		cp $(PLUGIN_NAME).so "$(INSTALL_PATH)$(PLUGIN_NAME).so.update";\
 	else\
 		cp $(PLUGIN_NAME).so "$(INSTALL_PATH)$(PLUGIN_NAME).so";\
 	fi
+	@echo $$(git -C $(HYPRLAND_HEADERS) rev-parse HEAD) > "$(INSTALL_PATH)$(PLUGIN_NAME).hlcommit"
 
 check_env:
 ifndef HYPRLAND_HEADERS
@@ -31,7 +32,7 @@ ifndef HYPRLAND_HEADERS
 endif
 
 $(OBJECT_DIR)/%.o: src/%.cpp
-	mkdir -p $(OBJECT_DIR)
+	@mkdir -p $(OBJECT_DIR)
 	g++ -c -o $@ $< $(COMPILE_FLAGS)
 
 $(PLUGIN_NAME).so: $(addprefix $(OBJECT_DIR)/, $(notdir $(SOURCE_FILES:.cpp=.o)))

--- a/include/Hyprload.hpp
+++ b/include/Hyprload.hpp
@@ -26,6 +26,8 @@ namespace hyprload {
       public:
         Hyprload();
 
+        bool checkIfHyprloadFullyCompatible();
+
         void handleTick();
 
         void installPlugins();
@@ -45,15 +47,19 @@ namespace hyprload {
 
         const std::vector<std::string>& getLoadedPlugins() const;
         bool isPluginLoaded(const std::string& name) const;
+        const std::string& getCurrentHyprlandCommitHash();
 
       private:
         std::optional<std::filesystem::path> getSessionBinariesPath();
         std::string generateSessionGuid();
         void setupHeaders();
+        std::string fetchHyprlandCommitHash();
 
         std::vector<std::string> m_vPlugins;
         std::optional<std::string> m_sSessionGuid;
         std::optional<flock_t> m_iSessionLock;
+
+        std::string m_sHyprlandCommitNow;
 
         bool m_bIsBuilding = false;
         std::vector<std::shared_ptr<BuildProcessDescriptor>> m_vBuildProcesses;


### PR DESCRIPTION
With these changes, hyprload doesn't interact with Hyprland internals outside of the plugin API unless the commit it was built with matches the commit of the running Hyprland exactly.

If hyprload is out of date with the hyprland commit hash, it can be assumed the other plugins are as well. A force rebuild is done.