### PR TITLE
Fix crash on config parse error

### DIFF
--- a/src/HyprloadConfig.cpp
+++ b/src/HyprloadConfig.cpp
@@ -6,6 +6,7 @@
 
 #include "toml/toml.hpp"
 
+#include <cstddef>
 #include <hyprland/src/config/ConfigManager.hpp>
 
 namespace hyprload::config {
@@ -21,6 +22,7 @@ namespace hyprload::config {
         } catch (const std::exception& e) {
             const std::string error = e.what();
             hyprload::error("Failed to parse config file: " + error);
+            return;
         }
 
         if (m_pConfig->contains("plugins") && m_pConfig->get("plugins")->is_array()) {
@@ -40,6 +42,7 @@ namespace hyprload::config {
                     }
                 });
         }
+
     }
 
     void HyprloadConfig::reloadConfig() {
@@ -51,6 +54,7 @@ namespace hyprload::config {
         } catch (const std::exception& e) {
             const std::string error = e.what();
             hyprload::error("Failed to parse config file: " + error);
+            return;
         }
 
         if (m_pConfig->contains("plugins") && m_pConfig->get("plugins")->is_array()) {


### PR DESCRIPTION
### Fixed crash on bad configuration
When the configuration is not parsed correctly, an exception is thrown. When we catch it, `m_pConfig = nullptr`.
Then `if (m_pConfig->contains("plugins") && m_pConfig->get("plugins")->is_array())` also throws an exception because m_pConfig is nullptr.
I think we need to return when we catch the first exception