### PR TITLE
Fix spamming error commit misatch when use package source

### DIFF
--- a/src/Hyprload.cpp
+++ b/src/Hyprload.cpp
@@ -72,6 +72,10 @@ namespace hyprload {
             return false;
         }
 
+        if (hyprlandCommitWhenBuilt == "") {
+            return true; // Source from package manager return no commit id
+        }
+
         if (hyprlandCommitWhenBuilt != getCurrentHyprlandCommitHash()) {
             debug("hyprlandCommitWhenBuilt: " + hyprlandCommitWhenBuilt);
             debug("hyprlandCommitNow: " + getCurrentHyprlandCommitHash());


### PR DESCRIPTION
When i install hyprland source with hyprland-devel in fedora.
It spam error because it can't set commit ID. 

Configuration

```bash
HYPRLAND_HEADERS=/usr/include/hyprland make -C ~/.local/share/hyprload/src install
```

copr: solopasha/hyprland
package installed:

      - hyprland-nvidia
      - hyprland-devel
      - libdrm-devel # For hyprload
      - libinput-devel # For hyprload
      - libudev-devel # For hyprload
      - wayland-devel # For hyprload
      - libxkbcommon-devel # For hyprload
      - xcb-util-wm-devel # For hyprload
      - xdg-desktop-portal-hyprland