### PR TITLE
Added dependency cpio to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - `jq` (required for checking Hyprland version)
 - `polkit` (required to set up Hyprland plugin env)
     - You will need an authentication agent set up. `lxsession` works for me.
+- `cpio` (required during installation for file management)
 
 # Installing
 1. Install `hyprload`


### PR DESCRIPTION
The install.sh script errored for me at step 6, because in my Arch System, cpio was not found. After installing it, it works. 