### PR TITLE
Updated file path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 1. Install `hyprload`
     - `curl -sSL https://raw.githubusercontent.com/Duckonaut/hyprload/main/install.sh | bash`
 2. Add this to your config to initialize `hyprload`
-    - `exec-once=$HOME/.local/share/hyprload/hyprload.sh`
+    - `exec-once=$HOME/.local/share/hyprload/src/hyprload.sh`
 
 # Setup
 1. To have hyprload manage your plugin installation, create a `hyprload.toml` file (by default, next to your `hyprland.conf` config: `~/.config/hypr/hyprload.toml`


### PR DESCRIPTION
it seems like the install path given in the README is wrong, as mine installed to `/home/twig/.local/share/hyperload/src/hyperload.sh` 

![image](https://github.com/Duckonaut/hyprload/assets/47639983/6d2ea038-ccc8-4cd2-81b9-751ff89717b6)

this might just be some weird installer issues on my side, unsure